### PR TITLE
[FD] Players can now eat food and grow from it

### DIFF
--- a/food.cpp
+++ b/food.cpp
@@ -37,8 +37,8 @@ void test_food()
   #ifndef NDEBUG // no tests in release
   {
     const food f;
-    assert(f.get_x() == 0.0);
-    assert(f.get_y() == 0.0);
+    assert(f.get_x() == 2000.0);
+    assert(f.get_y() == 1000.0);
   }
 
   //foods that are on the same coordinate point but with different colour Are equal, when this is not true

--- a/food.h
+++ b/food.h
@@ -7,7 +7,7 @@
 class food
 {
 public:
-  food(const double x = 0.0, const double y = 0.0, const color &c = color(), const double timer=0.0, food_state food_state = food_state::uneaten);
+  food(const double x = 2000.0, const double y = 1000.0, const color &c = color(), const double timer=0.0, food_state food_state = food_state::uneaten);
 
   const color &get_color() const noexcept { return m_color; }
   double get_x() const noexcept;

--- a/game.cpp
+++ b/game.cpp
@@ -121,14 +121,6 @@ bool has_food(const game &g)
   return false ;
 }
 
-void game::eat_nth_food(const int n)
-{
-  if(get_food()[n].is_eaten()) {
-      throw std::logic_error("You cannot eat food that already has been eaten!");
-    }
-  get_food()[n].set_food_state(food_state::eaten);
-}
-
 int count_n_projectiles(const game &g) noexcept
 {
   return static_cast<int>(g.get_projectiles().size());
@@ -569,7 +561,7 @@ void game::make_players_eat_food()
        {
           if (are_colliding(player, get_food()[i]))
             {
-              eat_nth_food(i);
+              eat_food(get_food()[i]);
               player.grow();
             }
        }
@@ -582,6 +574,14 @@ void game::eat_food(food& f)
       throw std::logic_error("You cannot eat food that already has been eaten!");
     }
   f.set_food_state(food_state::eaten);
+}
+
+void eat_nth_food(game& g, const int n)
+{
+    if(g.get_food()[n].is_eaten()) {
+        throw std::logic_error("You cannot eat food that already has been eaten!");
+    }
+    g.eat_food(g.get_food()[n]);
 }
 
 std::default_random_engine& game::get_rng() noexcept
@@ -1300,10 +1300,10 @@ void test_game() //!OCLINT tests may be many
   {
     game g; //by default one uneaten food
     assert(has_food(g));
-    g.eat_nth_food(0);
+    eat_nth_food(g, 0);
     assert(!has_food(g));
     try {
-      g.eat_nth_food(0); // throws exception
+      eat_nth_food(g, 0); // throws exception
     }
     catch ( const std::exception& e ) {
       assert(std::string(e.what()) == std::string("You cannot eat food that already has been eaten!"));
@@ -1318,7 +1318,7 @@ void test_game() //!OCLINT tests may be many
     game g; //by default one uneaten food
     const int n_food_items_begin = count_food_items(g);
     assert(has_food(g));
-    g.eat_nth_food(0);
+    eat_nth_food(g, 0);
     assert(!has_food(g));
     assert(n_food_items_begin == count_food_items(g));
   }
@@ -1340,7 +1340,7 @@ void test_game() //!OCLINT tests may be many
     game g; //by default one uneaten food
     assert(has_food(g));
     auto initial_value_timer = get_nth_food_timer(g, 0);
-    g.eat_nth_food(0);
+    eat_nth_food(g, 0);
     assert(!has_food(g));
     g.tick();
     assert(init_value_timer + 1  == get_nth_food_timer(g, 0));
@@ -1350,7 +1350,7 @@ void test_game() //!OCLINT tests may be many
 #ifdef FIX_ISSUE_255
   {
     game g;
-    g.eat_nth_food(0);
+    eat_nth_food(g, 0);
     assert(nth_food_is_eaten(g,0));
     for(int i = 0; i != get_nth_food_regeneration_time(g, 0); i++)
       {

--- a/game.cpp
+++ b/game.cpp
@@ -570,7 +570,7 @@ void game::make_players_eat_food()
           if (in_contact_with_uneaten_food(player, get_food()[i]))
             {
               eat_nth_food(i);
-              // player.grow();
+              player.grow();
             }
        }
     }
@@ -1252,7 +1252,7 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
-// #define FIX_ISSUE_244
+#define FIX_ISSUE_244
 #ifdef FIX_ISSUE_244
   {
     game g;

--- a/game.cpp
+++ b/game.cpp
@@ -1271,21 +1271,6 @@ void test_game() //!OCLINT tests may be many
 
 #endif
 
-//#define FIX_ISSUE_359
-#ifdef FIX_ISSUE_359
-  {
-    game g;
-    const auto init_nb_of_food = g.get_food().size();
-    // Food should not be consumed if nothing happens
-    g.tick();
-    assert(g.get_food().size() == init_nb_of_food);
-    // Food should be consumed if a player is on it
-    put_player_on_food(g.get_player(0), g.get_food()[0]);
-    g.tick();
-    assert(g.get_food().size() == init_nb_of_food - 1);
-  }
-#endif // FIX_ISSUE_359
-
 #define FIX_ISSUE_247
 #ifdef FIX_ISSUE_247
   {

--- a/game.cpp
+++ b/game.cpp
@@ -1248,13 +1248,14 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
+// #define FIX_ISSUE_238
 #ifdef FIX_ISSUE_238
-  //Food and player can be overlapped
+  // The game can be checked for any collision between food and players
   {
     game g;
-    assert(!has_player_food_collision(g));
+    assert(!any_player_food_collision(g));
     put_player_on_food(g.get_player(0), g.get_food()[0]);
-    assert(has_player_food_collision(g));
+    assert(any_player_food_collision(g));
   }
 #endif
 

--- a/game.cpp
+++ b/game.cpp
@@ -487,18 +487,18 @@ bool have_same_position(const player& p, const food& f)
       p.get_y() - f.get_y() > -0.0001;
 }
 
-bool in_contact_with_uneaten_food(const player &p, const food &f)
+bool are_colliding(const player &p, const food &f)
 {
   return have_same_position(p, f) && !f.is_eaten();
 }
 
-bool any_player_food_collision(const game& g)
+bool has_any_player_food_collision(const game& g)
 {
   for (auto& p : g.get_v_player())
     {
       for(auto& f : g.get_food())
         {
-          if (in_contact_with_uneaten_food(p, f))
+          if (are_colliding(p, f))
             {
               return true;
             }
@@ -567,7 +567,7 @@ void game::make_players_eat_food()
     {
       for(int i = 0; i < n_food; ++i)
        {
-          if (in_contact_with_uneaten_food(player, get_food()[i]))
+          if (are_colliding(player, get_food()[i]))
             {
               eat_nth_food(i);
               player.grow();
@@ -969,7 +969,7 @@ void test_game() //!OCLINT tests may be many
   // In the start of the game, there is no player-food collision
   {
     game g;
-    assert(!any_player_food_collision(g));
+    assert(!has_any_player_food_collision(g));
   }
 
   //Can modify food items, for example, delete all food items
@@ -1062,7 +1062,7 @@ void test_game() //!OCLINT tests may be many
   // In the start of the game, there is no player-food collision
   {
     game g;
-    assert(!any_player_food_collision(g));
+    assert(!has_any_player_food_collision(g));
   }
 
   //Can modify food items, for example, delete all food items
@@ -1223,10 +1223,10 @@ void test_game() //!OCLINT tests may be many
     game g;
     put_player_on_food(g.get_player(0), g.get_food()[0]);
     assert(has_food(g));
-    assert(any_player_food_collision(g));
+    assert(has_any_player_food_collision(g));
     g.tick();
     assert(!has_food(g));
-    assert(!any_player_food_collision(g));
+    assert(!has_any_player_food_collision(g));
   }
 #endif
 
@@ -1246,9 +1246,9 @@ void test_game() //!OCLINT tests may be many
   // The game can be checked for any collision between food and players
   {
     game g;
-    assert(!any_player_food_collision(g));
+    assert(!has_any_player_food_collision(g));
     put_player_on_food(g.get_player(0), g.get_food()[0]);
-    assert(any_player_food_collision(g));
+    assert(has_any_player_food_collision(g));
   }
 #endif
 
@@ -1267,13 +1267,11 @@ void test_game() //!OCLINT tests may be many
 #define FIX_ISSUE_247
 #ifdef FIX_ISSUE_247
   {
-    double p_x = 12.3;
-    double f_x = p_x + 1.0;
-    player p{p_x};
-    food f{f_x};
-    assert(!in_contact_with_uneaten_food(p,f));
+    player p{12.3};
+    food f{12.3 + 1.0};
+    assert(!are_colliding(p,f));
     put_player_on_food(p,f);
-    assert(in_contact_with_uneaten_food(p,f));
+    assert(are_colliding(p,f));
   }
 #endif // FIX_ISSUE_247
 
@@ -1331,9 +1329,9 @@ void test_game() //!OCLINT tests may be many
     food f;
     player p;
     put_player_on_food(p, f);
-    assert(in_contact_with_uneaten_food(p,f));
+    assert(are_colliding(p,f));
     f.set_food_state(food_state::eaten);
-    assert(!in_contact_with_uneaten_food(p,f));
+    assert(!are_colliding(p,f));
   }
 #endif
 

--- a/game.cpp
+++ b/game.cpp
@@ -1231,18 +1231,32 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
+#define FIX_ISSUE_244
 #ifdef FIX_ISSUE_244
-
   {
     game g;
     const auto init_player_size = get_nth_player_size(g,0);
     put_player_on_food(g.get_player(0), g.get_food()[0]);
     g.tick();
     assert(g.get_player(0).get_diameter() > init_player_size);
-
   }
 
 #endif
+
+//#define FIX_ISSUE_359
+#ifdef FIX_ISSUE_359
+  {
+    game g;
+    const auto init_nb_of_food = g.get_food().size();
+    // Food should not be consumed if nothing happens
+    g.tick();
+    assert(g.get_food().size() == init_nb_of_food);
+    // Food should be consumed if a player is on it
+    put_player_on_food(g.get_player(0), g.get_food()[0]);
+    g.tick();
+    assert(g.get_food().size() == init_nb_of_food - 1);
+  }
+#endif // FIX_ISSUE_359
 
 #define FIX_ISSUE_247
 #ifdef FIX_ISSUE_247
@@ -1255,7 +1269,7 @@ void test_game() //!OCLINT tests may be many
     put_player_on_food(p,f);
     assert(player_and_food_are_colliding(p,f));
   }
-#endif
+#endif // FIX_ISSUE_247
 
 #ifdef FIX_ISSUE_248
 

--- a/game.cpp
+++ b/game.cpp
@@ -402,29 +402,6 @@ bool has_wall_collision(const game& g)
   return false;
 }
 
-bool any_player_food_collision(const game& g)
-{
-  for (auto& p : g.get_v_player())
-    {
-      for(auto& f : g.get_food())
-        {
-          if (in_contact_with_uneaten_food(p, f))
-            {
-              return true;
-            }
-        }
-    }
-  return false;
-}
-
-bool have_same_position(const player& p, const food& f)
-{
-  return p.get_x() - f.get_x() < 0.0001 &&
-      p.get_x() - f.get_x() > -0.0001 &&
-      p.get_y() - f.get_y() < 0.0001 &&
-      p.get_y() - f.get_y() > -0.0001;
-}
-
 bool hits_south_wall(const player& p, const environment& e)
 {
   return p.get_y() + p.get_diameter()/2 > e.get_max_y();
@@ -502,9 +479,32 @@ void put_player_on_food(player &p, const food &f)
   p.place_to_position(get_position(f));
 }
 
+bool have_same_position(const player& p, const food& f)
+{
+  return p.get_x() - f.get_x() < 0.0001 &&
+      p.get_x() - f.get_x() > -0.0001 &&
+      p.get_y() - f.get_y() < 0.0001 &&
+      p.get_y() - f.get_y() > -0.0001;
+}
+
 bool in_contact_with_uneaten_food(const player &p, const food &f)
 {
-  return p.get_x() == f.get_x() && p.get_y() == f.get_y();
+  return have_same_position(p, f) && !f.is_eaten();
+}
+
+bool any_player_food_collision(const game& g)
+{
+  for (auto& p : g.get_v_player())
+    {
+      for(auto& f : g.get_food())
+        {
+          if (in_contact_with_uneaten_food(p, f))
+            {
+              return true;
+            }
+        }
+    }
+  return false;
 }
 
 void put_projectile_in_front_of_player(std::vector<projectile>& projectiles, const player& p)

--- a/game.cpp
+++ b/game.cpp
@@ -1286,7 +1286,7 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
-// #define FIX_ISSUE_254
+#define FIX_ISSUE_254
 #ifdef FIX_ISSUE_254
   {
     game g;

--- a/game.cpp
+++ b/game.cpp
@@ -562,13 +562,22 @@ void game::make_players_eat_food()
     {
       for(auto& food : m_food)
        {
-          if (player_and_food_are_colliding(player, food))
+          if (player_and_food_are_colliding(player, food)
+              && !food.is_eaten())
             {
               eat_food(food);
-              make_player_grow(player);
+              player.grow();
             }
        }
     }
+}
+
+void game::eat_food(food& f)
+{
+  if(f.is_eaten()) {
+      throw std::logic_error("You cannot eat food that already has been eaten!");
+    }
+  f.set_food_state(food_state::eaten);
 }
 
 std::default_random_engine& game::get_rng() noexcept

--- a/game.cpp
+++ b/game.cpp
@@ -402,11 +402,6 @@ bool has_wall_collision(const game& g)
   return false;
 }
 
-bool has_enemy_collision(const game&)
-{
-  return false;
-}
-
 bool any_player_food_collision(const game& g)
 {
   for (auto& p : g.get_v_player())
@@ -985,11 +980,6 @@ void test_game() //!OCLINT tests may be many
     g.get_food().clear();
     assert(g.get_food().empty());
   }
-  // In the start of the game, there is no player-enemy collision
-  {
-    game g;
-    assert(!has_enemy_collision(g));
-  }
   //If red eats green then red survives
   {
     game g;
@@ -1082,11 +1072,6 @@ void test_game() //!OCLINT tests may be many
     assert(!g.get_food().empty());
     g.get_food().clear();
     assert(g.get_food().empty());
-  }
-  // In the start of the game, there is no player-enemy collision
-  {
-    game g;
-    assert(!has_enemy_collision(g));
   }
   //If red eats green then red survives
   {

--- a/game.cpp
+++ b/game.cpp
@@ -408,7 +408,7 @@ bool any_player_food_collision(const game& g)
     {
       for(auto& f : g.get_food())
         {
-          if (player_and_food_are_colliding(p, f))
+          if (in_contact_with_uneaten_food(p, f))
             {
               return true;
             }
@@ -502,7 +502,7 @@ void put_player_on_food(player &p, const food &f)
   p.place_to_position(get_position(f));
 }
 
-bool player_and_food_are_colliding(const player &p, const food &f)
+bool in_contact_with_uneaten_food(const player &p, const food &f)
 {
   return p.get_x() == f.get_x() && p.get_y() == f.get_y();
 }
@@ -566,7 +566,7 @@ void game::make_players_eat_food()
     {
       for(auto& food : m_food)
        {
-          if (player_and_food_are_colliding(player, food)
+          if (in_contact_with_uneaten_food(player, food)
               && !food.is_eaten())
             {
               eat_food(food);
@@ -1271,9 +1271,9 @@ void test_game() //!OCLINT tests may be many
     double f_x = p_x + 1.0;
     player p{p_x};
     food f{f_x};
-    assert(!player_and_food_are_colliding(p,f));
+    assert(!in_contact_with_uneaten_food(p,f));
     put_player_on_food(p,f);
-    assert(player_and_food_are_colliding(p,f));
+    assert(in_contact_with_uneaten_food(p,f));
   }
 #endif // FIX_ISSUE_247
 
@@ -1329,9 +1329,9 @@ void test_game() //!OCLINT tests may be many
     food f;
     player p;
     put_player_on_food(p, f);
-    assert(player_and_food_are_colliding(p,f));
+    assert(in_contact_with_uneaten_food(p,f));
     eat_nth_food(g,0);
-    assert(!player_and_food_are_colliding(p,f));
+    assert(!in_contact_with_uneaten_food(p,f));
   }
 #endif
 

--- a/game.cpp
+++ b/game.cpp
@@ -570,7 +570,7 @@ void game::make_players_eat_food()
           if (in_contact_with_uneaten_food(player, get_food()[i]))
             {
               eat_nth_food(i);
-              player.grow();
+              // player.grow();
             }
        }
     }

--- a/game.cpp
+++ b/game.cpp
@@ -413,6 +413,21 @@ bool has_food_collision(const game &) noexcept
   return false;
 }
 
+bool any_player_food_collision(const game& g)
+{
+  for (auto& p : g.get_v_player())
+    {
+      for(auto& f : g.get_food())
+        {
+          if (player_and_food_are_colliding(p, f))
+            {
+              return true;
+            }
+        }
+    }
+  return false;
+}
+
 bool have_same_position(const player& p, const food& f)
 {
   return p.get_x() - f.get_x() < 0.0001 &&
@@ -1223,16 +1238,15 @@ void test_game() //!OCLINT tests may be many
   }
 
 #ifdef FIX_ISSUE_236
-  //When a player touches food it destroys it
+  //When a player touches food it eats it
   {
-
     game g;
     put_player_on_food(g.get_player(0), g.get_food()[0]);
     assert(has_food(g))
-        assert(has_player_food_collision(g));
+        assert(any_player_food_collision(g));
     g.tick();
     assert(!has_food(g));
-    assert(!has_player_food_collision(g));
+    assert(!any_player_food_collision(g));
 
   }
 #endif
@@ -1248,7 +1262,7 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
-// #define FIX_ISSUE_238
+#define FIX_ISSUE_238
 #ifdef FIX_ISSUE_238
   // The game can be checked for any collision between food and players
   {

--- a/game.cpp
+++ b/game.cpp
@@ -112,14 +112,13 @@ int count_food_items(const game &g)
 bool has_food(const game &g)
 {
   std::vector<food> v_food{g.get_food()};
-  int count = 0;
   for (unsigned int i = 0; i < v_food.size(); i++) {
       if (!v_food[i].is_eaten())
         {
-          count++;
+          return true;
         }
     }
-  return count > 0 ;
+  return false ;
 }
 
 void eat_nth_food(game &g, const int n)
@@ -404,11 +403,6 @@ bool has_wall_collision(const game& g)
 }
 
 bool has_enemy_collision(const game&)
-{
-  return false;
-}
-
-bool has_food_collision(const game &) noexcept
 {
   return false;
 }
@@ -980,7 +974,7 @@ void test_game() //!OCLINT tests may be many
   // In the start of the game, there is no player-food collision
   {
     game g;
-    assert(!has_food_collision(g));
+    assert(!any_player_food_collision(g));
   }
 
   //Can modify food items, for example, delete all food items
@@ -1078,7 +1072,7 @@ void test_game() //!OCLINT tests may be many
   // In the start of the game, there is no player-food collision
   {
     game g;
-    assert(!has_food_collision(g));
+    assert(!any_player_food_collision(g));
   }
 
   //Can modify food items, for example, delete all food items
@@ -1237,17 +1231,17 @@ void test_game() //!OCLINT tests may be many
     assert(is_dead(g.get_player(0)));
   }
 
+#define FIX_ISSUE_236
 #ifdef FIX_ISSUE_236
   //When a player touches food it eats it
   {
     game g;
     put_player_on_food(g.get_player(0), g.get_food()[0]);
-    assert(has_food(g))
-        assert(any_player_food_collision(g));
+    assert(has_food(g));
+    assert(any_player_food_collision(g));
     g.tick();
     assert(!has_food(g));
     assert(!any_player_food_collision(g));
-
   }
 #endif
 
@@ -1273,7 +1267,7 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
-#define FIX_ISSUE_244
+// #define FIX_ISSUE_244
 #ifdef FIX_ISSUE_244
   {
     game g;

--- a/game.cpp
+++ b/game.cpp
@@ -562,14 +562,14 @@ player game::wall_collision(player p)
 
 void game::make_players_eat_food()
 {
+  int n_food = static_cast<int>(get_food().size());
   for(auto& player : m_player)
     {
-      for(auto& food : m_food)
+      for(int i = 0; i < n_food; ++i)
        {
-          if (in_contact_with_uneaten_food(player, food)
-              && !food.is_eaten())
+          if (in_contact_with_uneaten_food(player, get_food()[i]))
             {
-              eat_food(food);
+              eat_nth_food(i);
               player.grow();
             }
        }
@@ -1216,7 +1216,7 @@ void test_game() //!OCLINT tests may be many
     assert(is_dead(g.get_player(0)));
   }
 
-#define FIX_ISSUE_236
+// #define FIX_ISSUE_236
 #ifdef FIX_ISSUE_236
   //When a player touches food it eats it
   {
@@ -1286,12 +1286,13 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
+// #define FIX_ISSUE_254
 #ifdef FIX_ISSUE_254
   {
     game g;
     put_player_on_food(g.get_player(0), g.get_food()[0]);
     g.tick();
-    assert(is_eaten(g.get_food()[0]))
+    assert(g.get_food()[0].is_eaten());
   }
 #endif
 
@@ -1324,13 +1325,14 @@ void test_game() //!OCLINT tests may be many
     assert(n_food_items_begin == count_food_items(g));
   }
 
+#define FIX_ISSUE_256
 #ifdef FIX_ISSUE_256
   {
     food f;
     player p;
     put_player_on_food(p, f);
     assert(in_contact_with_uneaten_food(p,f));
-    g.eat_nth_food(0);
+    f.set_food_state(food_state::eaten);
     assert(!in_contact_with_uneaten_food(p,f));
   }
 #endif

--- a/game.cpp
+++ b/game.cpp
@@ -121,12 +121,12 @@ bool has_food(const game &g)
   return false ;
 }
 
-void eat_nth_food(game &g, const int n)
+void game::eat_nth_food(const int n)
 {
-  if(g.get_food()[n].is_eaten()) {
+  if(get_food()[n].is_eaten()) {
       throw std::logic_error("You cannot eat food that already has been eaten!");
     }
-  g.get_food()[n].set_food_state(food_state::eaten);
+  get_food()[n].set_food_state(food_state::eaten);
 }
 
 int count_n_projectiles(const game &g) noexcept
@@ -1301,10 +1301,10 @@ void test_game() //!OCLINT tests may be many
   {
     game g; //by default one uneaten food
     assert(has_food(g));
-    eat_nth_food(g,0);
+    g.eat_nth_food(0);
     assert(!has_food(g));
     try {
-      eat_nth_food(g,0); // throws exception
+      g.eat_nth_food(0); // throws exception
     }
     catch ( const std::exception& e ) {
       assert(std::string(e.what()) == std::string("You cannot eat food that already has been eaten!"));
@@ -1319,7 +1319,7 @@ void test_game() //!OCLINT tests may be many
     game g; //by default one uneaten food
     const int n_food_items_begin = count_food_items(g);
     assert(has_food(g));
-    eat_nth_food(g,0);
+    g.eat_nth_food(0);
     assert(!has_food(g));
     assert(n_food_items_begin == count_food_items(g));
   }
@@ -1330,7 +1330,7 @@ void test_game() //!OCLINT tests may be many
     player p;
     put_player_on_food(p, f);
     assert(in_contact_with_uneaten_food(p,f));
-    eat_nth_food(g,0);
+    g.eat_nth_food(0);
     assert(!in_contact_with_uneaten_food(p,f));
   }
 #endif
@@ -1340,7 +1340,7 @@ void test_game() //!OCLINT tests may be many
     game g; //by default one uneaten food
     assert(has_food(g));
     auto initial_value_timer = get_nth_food_timer(g, 0);
-    eat_nth_food(g,0);
+    g.eat_nth_food(0);
     assert(!has_food(g));
     g.tick();
     assert(init_value_timer + 1  == get_nth_food_timer(g, 0));
@@ -1350,7 +1350,7 @@ void test_game() //!OCLINT tests may be many
 #ifdef FIX_ISSUE_255
   {
     game g;
-    eat_nth_food(g, 0);
+    g.eat_nth_food(0);
     assert(nth_food_is_eaten(g,0));
     for(int i = 0; i != get_nth_food_regeneration_time(g, 0); i++)
       {

--- a/game.cpp
+++ b/game.cpp
@@ -1216,7 +1216,7 @@ void test_game() //!OCLINT tests may be many
     assert(is_dead(g.get_player(0)));
   }
 
-// #define FIX_ISSUE_236
+#define FIX_ISSUE_236
 #ifdef FIX_ISSUE_236
   //When a player touches food it eats it
   {

--- a/game.cpp
+++ b/game.cpp
@@ -1268,6 +1268,8 @@ void test_game() //!OCLINT tests may be many
   }
 #endif
 
+  #define FIX_ISSUE_340
+  #ifdef FIX_ISSUE_340
   // make sure that eat_nth_food() throws a logic_error when the food is already eaten
   {
     game g; //by default one uneaten food
@@ -1281,6 +1283,8 @@ void test_game() //!OCLINT tests may be many
       assert(std::string(e.what()) == std::string("You cannot eat food that already has been eaten!"));
     }
   }
+  #endif // FIX_ISSUE_340
+
   // number of food item stays the same,
   // only the state of food item changes after they are eaten
   // eaten food items are ?probably removed by game::tick

--- a/game.cpp
+++ b/game.cpp
@@ -495,6 +495,11 @@ void put_player_on_food(player &p, const food &f)
   p.place_to_position(get_position(f));
 }
 
+bool player_and_food_are_colliding(const player &p, const food &f)
+{
+  return p.get_x() == f.get_x() && p.get_y() == f.get_y();
+}
+
 void put_projectile_in_front_of_player(std::vector<projectile>& projectiles, const player& p)
 {
   // Put the projectile just in front outside of the player
@@ -1239,14 +1244,16 @@ void test_game() //!OCLINT tests may be many
 
 #endif
 
+#define FIX_ISSUE_247
 #ifdef FIX_ISSUE_247
   {
-    player p;
-    food f;
+    double p_x = 12.3;
+    double f_x = p_x + 1.0;
+    player p{p_x};
+    food f{f_x};
     assert(!player_and_food_are_colliding(p,f));
     put_player_on_food(p,f);
     assert(player_and_food_are_colliding(p,f));
-
   }
 #endif
 

--- a/game.cpp
+++ b/game.cpp
@@ -301,6 +301,9 @@ void game::tick()
   //Check and resolve wall collisions
   do_wall_collisions();
 
+  // Make players eat food
+  make_players_eat_food();
+
   // players that shoot must generate projectiles
   for (player &p : m_player)
     {
@@ -551,6 +554,21 @@ player game::wall_collision(player p)
     }
 
   return p;
+}
+
+void game::make_players_eat_food()
+{
+  for(auto& player : m_player)
+    {
+      for(auto& food : m_food)
+       {
+          if (player_and_food_are_colliding(player, food))
+            {
+              eat_food(food);
+              make_player_grow(player);
+            }
+       }
+    }
 }
 
 std::default_random_engine& game::get_rng() noexcept

--- a/game.h
+++ b/game.h
@@ -207,11 +207,11 @@ void kill_losing_player(game &);
 ///Puts a player on food
 void put_player_on_food(player& p, const food &f);
 
-/// Check that player and food are on top of one another
-bool in_contact_with_uneaten_food(const player &p, const food &f);
+/// Check that player and food are in collision, i.e. same position and food uneaten
+bool are_colliding(const player &p, const food &f);
 
 /// Check the game for any collision between food and players
-bool any_player_food_collision(const game& g);
+bool has_any_player_food_collision(const game& g);
 
 ///Places a projectile in front of the player
 void put_projectile_in_front_of_player(std::vector<projectile>& projectiles, const player& p);

--- a/game.h
+++ b/game.h
@@ -117,6 +117,9 @@ public:
   ///Manages collisons with walls
   player wall_collision(player p);
 
+  // Eat nth food item
+  void eat_nth_food(const int n);
+
 private:
 
   /// The RNG engine

--- a/game.h
+++ b/game.h
@@ -204,6 +204,9 @@ void kill_losing_player(game &);
 ///Puts a player on food
 void put_player_on_food(player& p, const food &f);
 
+/// Check that player and food are on top of one another
+bool player_and_food_are_colliding(const player &p, const food &f);
+
 ///Places a projectile in front of the player
 void put_projectile_in_front_of_player(std::vector<projectile>& projectiles, const player& p);
 

--- a/game.h
+++ b/game.h
@@ -186,9 +186,6 @@ bool has_collision(const game &g) noexcept;
 /// Determines if the player and projectile collide
 bool has_collision(const player& pl, const projectile& p);
 
-/// Is there a collision between an enemy and player?
-bool has_enemy_collision(const game& g);
-
 ///Checks if a player and food have the same exact position
 bool have_same_position(const player& p, const food& f);
 

--- a/game.h
+++ b/game.h
@@ -160,6 +160,9 @@ private:
 
   // Make players eat food items they are on top of
   void make_players_eat_food();
+
+  // Switch a food item's state to eaten
+  void eat_food(food& f);
 };
 
 

--- a/game.h
+++ b/game.h
@@ -205,7 +205,7 @@ void kill_losing_player(game &);
 void put_player_on_food(player& p, const food &f);
 
 /// Check that player and food are on top of one another
-bool player_and_food_are_colliding(const player &p, const food &f);
+bool in_contact_with_uneaten_food(const player &p, const food &f);
 
 /// Check the game for any collision between food and players
 bool any_player_food_collision(const game& g);

--- a/game.h
+++ b/game.h
@@ -189,9 +189,6 @@ bool has_collision(const player& pl, const projectile& p);
 /// Is there a collision between an enemy and player?
 bool has_enemy_collision(const game& g);
 
-///Checks if there are collisions with food items
-bool has_food_collision(const game &) noexcept;
-
 ///Checks if a player and food have the same exact position
 bool have_same_position(const player& p, const food& f);
 
@@ -212,6 +209,9 @@ void put_player_on_food(player& p, const food &f);
 
 /// Check that player and food are on top of one another
 bool player_and_food_are_colliding(const player &p, const food &f);
+
+/// Check the game for any collision between food and players
+bool any_player_food_collision(const game& g);
 
 ///Places a projectile in front of the player
 void put_projectile_in_front_of_player(std::vector<projectile>& projectiles, const player& p);

--- a/game.h
+++ b/game.h
@@ -155,8 +155,11 @@ private:
   /// Moves the projectiles
   void move_projectiles();
 
-  /// Processess the collsion between projectiles and players
+  /// Processess the collision between projectiles and players
   void projectile_collision();
+
+  // Make players eat food items they are on top of
+  void make_players_eat_food();
 };
 
 

--- a/game.h
+++ b/game.h
@@ -55,6 +55,9 @@ public:
 
   /// Increment the number of ticks
   void increment_n_ticks();
+    
+  // Switch a food item's state to eaten
+  void eat_food(food& f);
 
   /// Get environment size of the game
   const environment& get_env() const noexcept{ return m_environment; }
@@ -117,9 +120,6 @@ public:
   ///Manages collisons with walls
   player wall_collision(player p);
 
-  // Eat nth food item
-  void eat_nth_food(const int n);
-
 private:
 
   /// The RNG engine
@@ -164,8 +164,6 @@ private:
   // Make players eat food items they are on top of
   void make_players_eat_food();
 
-  // Switch a food item's state to eaten
-  void eat_food(food& f);
 };
 
 
@@ -182,6 +180,9 @@ void add_projectile(game& g, const projectile& p);
 int count_n_projectiles(const game &g) noexcept;
 
 int count_alive_players(const game& g) noexcept;
+
+// Eat nth food item
+void eat_nth_food(game& g, const int n);
 
 /// checks if there is at least one collision between players in the game
 bool has_collision(const game &g) noexcept;

--- a/player.cpp
+++ b/player.cpp
@@ -48,6 +48,12 @@ double player::get_y() const noexcept { return m_y; }
 /// Get the radius of the player
 double player::get_diameter() const noexcept { return m_diameter; }
 
+/// Make the player grow
+void player::grow()
+{
+  m_diameter *= m_growth_factor;
+}
+
 /// Get the direction of player movement, in radians
 double player::get_direction() const noexcept { return m_direction_radians; }
 

--- a/player.h
+++ b/player.h
@@ -131,7 +131,8 @@ public:
     /// Accelerate the player backward
     void acc_backward() noexcept;
 
-
+    /// Make the player grow
+    void grow();
 
 private:
     /// The player's color, will change depending on food items
@@ -179,6 +180,9 @@ private:
 
     /// The size of the player
     double m_diameter;
+
+    /// How much a player grows when growing
+    double m_growth_factor = 1.1;
 
     /// The direction of player in radians
     double m_direction_radians = 270 * M_PI / 180;


### PR DESCRIPTION
Fixed a bunch of food-related issues [FD]: #254 , #238 , #244, #247, #236, #256
I modified some of these issues and their tests to make it clearer what they do or request

Also:
- changed default food position to {2000, 2000} to avoid player-wall collisions issues when testing
- made `eat_nth_food()` a public member of `game` so that it can be called from within and access other members of the class
- removed function `has_enemy_collision` and the corresponding test, as this function wasn't checking anything at all and so the test was misleading