### PR TITLE
The players have different keys for the "stun rocket" action

### DIFF
--- a/game_view.cpp
+++ b/game_view.cpp
@@ -158,7 +158,7 @@ void game_view::draw_food() noexcept
 
 void game_view::press_key(const sf::Keyboard::Key& k)
 {
-    if(k == sf::Keyboard::Num1) {
+    if(k == sf::Keyboard::E) {
       /// stunning not shooting a rocket
       this->m_game.do_action(0, action_type::shoot_stun_rocket);
     }
@@ -509,7 +509,7 @@ void test_game_view()//!OCLINT tests may be many
   {
     game_view g;
     assert(count_n_projectiles(g) == 0);
-    g.press_key(sf::Keyboard::Num1);
+    g.press_key(sf::Keyboard::E);
     g.process_events(); // Needed to process the event
     assert(count_n_projectiles(g) == 1);
   }

--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -85,7 +85,7 @@ key_action_map get_player_3_kam()
         sf::Keyboard::Down,
         //sf::Keyboard::Comma,
         sf::Keyboard::RControl,
-        sf::Keyboard::Enter
+        sf::Keyboard::Return
         );
 }
 

--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -83,7 +83,8 @@ key_action_map get_player_3_kam()
         sf::Keyboard::Up,
         sf::Keyboard::Down,
         //sf::Keyboard::Comma,
-        sf::Keyboard::RControl
+        sf::Keyboard::RControl,
+        sf::Keyboard::RShift
         );
 }
 

--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -72,7 +72,8 @@ key_action_map get_player_2_kam()
         sf::Keyboard::I,
         sf::Keyboard::K,
         //sf::Keyboard::Comma,
-        sf::Keyboard::U
+        sf::Keyboard::U,
+        sf::Keyboard::O
         );
 }
 key_action_map get_player_3_kam()
@@ -84,7 +85,7 @@ key_action_map get_player_3_kam()
         sf::Keyboard::Down,
         //sf::Keyboard::Comma,
         sf::Keyboard::RControl,
-        sf::Keyboard::RShift
+        sf::Keyboard::Enter
         );
 }
 
@@ -131,7 +132,7 @@ void test_key_action_map()//!OCLINT tests can be many
     assert(m.to_action(sf::Keyboard::W) == action_type::accelerate);
     assert(m.to_action(sf::Keyboard::S) == action_type::brake);
     assert(m.to_action(sf::Keyboard::Q) == action_type::shoot);
-    assert(m.to_action(sf::Keyboard::Num1) == action_type::shoot_stun_rocket);
+    assert(m.to_action(sf::Keyboard::E) == action_type::shoot_stun_rocket);
   }
   {
     const key_action_map m = get_player_1_kam();
@@ -264,7 +265,7 @@ void test_key_action_map()//!OCLINT tests can be many
     assert(kam.to_key(action_type::accelerate) == sf::Keyboard::W);
     assert(kam.to_key(action_type::brake) == sf::Keyboard::S);
     assert(kam.to_key(action_type::shoot) == sf::Keyboard::Q);
-    assert(kam.to_key(action_type::shoot_stun_rocket) == sf::Keyboard::Num1);
+    assert(kam.to_key(action_type::shoot_stun_rocket) == sf::Keyboard::E);
   }
 #endif // FIX_ISSUE_355
 #define FIX_ISSUE_370

--- a/key_action_map.h
+++ b/key_action_map.h
@@ -15,7 +15,7 @@ public:
     const sf::Keyboard::Key& key_to_accelerate = sf::Keyboard::W,
     const sf::Keyboard::Key& key_to_brake = sf::Keyboard::S,
     const sf::Keyboard::Key& key_to_shoot = sf::Keyboard::Q,
-    const sf::Keyboard::Key& key_to_stun = sf::Keyboard::Num1
+    const sf::Keyboard::Key& key_to_stun = sf::Keyboard::E
   );
 
   ///Find out which action is triggered by that key


### PR DESCRIPTION
Changed the player keymaps for shooting stun rockets as follows:

player 1: E
player 2: O
player 3: Return

We're not sure about Return being a good option, but due to the fact that we have different keyboards, couldn't think of a better one.