### PR TITLE
Implement `player_profession`

### DIFF
--- a/color.cpp
+++ b/color.cpp
@@ -133,12 +133,8 @@ void test_color()
     std::stringstream s;
     const color c;
     s << c;
+    assert(!s.str().empty());
   }
-  {
-    const color c;
-    std::cout << c;
-  }
-
   // Colors have the correct RGB values
   {
     //  This is ISSUE_#322

--- a/enemy_behavior_type.cpp
+++ b/enemy_behavior_type.cpp
@@ -14,10 +14,7 @@ void test_enemy_behavior_type()
   {
     std::stringstream s;
     s << enemy_behavior_type::gezellig;
-
-  }
-  {
-    std::cout << enemy_behavior_type::gezellig;
+    assert(!s.str().empty());
   }
   {
     std::stringstream s;

--- a/game.pri
+++ b/game.pri
@@ -21,6 +21,7 @@ HEADERS += \
     $$PWD/optional.h \
     $$PWD/player.h \
     $$PWD/player_factory.h \
+    $$PWD/player_profession.h \
     $$PWD/player_shape.h \
     $$PWD/player_state.h \
     $$PWD/program_state.h \
@@ -53,6 +54,7 @@ SOURCES += \
     $$PWD/optional.cpp \
     $$PWD/player.cpp \
     $$PWD/player_factory.cpp \
+    $$PWD/player_profession.cpp \
     $$PWD/player_shape.cpp \
     $$PWD/player_state.cpp \
     $$PWD/program_state.cpp \

--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -168,11 +168,6 @@ sf::Keyboard::Key get_stun_key(const key_action_map& m)
   return m.to_key(action_type::shoot_stun_rocket);
 }
 
-bool exists_file (const std::string& name) {
-    std::ifstream f(name.c_str());
-    return f.good();
-}
-
 key_action_map load_kam(const std::string& filename)
 {
   std::ifstream f(filename);
@@ -392,7 +387,7 @@ void test_key_action_map()//!OCLINT tests can be many
   }
 #endif // FIX_ISSUE_355
 
-#define ISSUE_522
+//#define ISSUE_522
 #ifdef ISSUE_522
   {
     const key_action_map kam = get_player_1_kam();
@@ -403,7 +398,6 @@ void test_key_action_map()//!OCLINT tests can be many
     const key_action_map kam = get_player_1_kam();
     const std::string filename = "test.txt";
     save_to_file(kam, filename);
-    std::filesystem::exists;
     const key_action_map map_again = load_kam(filename);
     assert(kam == map_again);
     // TODO: delete temporary file

--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -168,6 +168,11 @@ sf::Keyboard::Key get_stun_key(const key_action_map& m)
   return m.to_key(action_type::shoot_stun_rocket);
 }
 
+bool exists_file (const std::string& name) {
+    std::ifstream f(name.c_str());
+    return f.good();
+}
+
 key_action_map load_kam(const std::string& filename)
 {
   std::ifstream f(filename);
@@ -387,7 +392,7 @@ void test_key_action_map()//!OCLINT tests can be many
   }
 #endif // FIX_ISSUE_355
 
-//#define ISSUE_522
+#define ISSUE_522
 #ifdef ISSUE_522
   {
     const key_action_map kam = get_player_1_kam();
@@ -398,6 +403,7 @@ void test_key_action_map()//!OCLINT tests can be many
     const key_action_map kam = get_player_1_kam();
     const std::string filename = "test.txt";
     save_to_file(kam, filename);
+    std::filesystem::exists;
     const key_action_map map_again = load_kam(filename);
     assert(kam == map_again);
     // TODO: delete temporary file

--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -1,6 +1,7 @@
 #include "key_action_map.h"
 #include <cassert>
-
+#include <fstream>
+#include <iostream>
 key_action_map::key_action_map(
     const sf::Keyboard::Key& key_to_go_left,
     const sf::Keyboard::Key& key_to_go_right,
@@ -163,6 +164,20 @@ sf::Keyboard::Key get_stun_key(const key_action_map& m)
   return m.to_key(action_type::shoot_stun_rocket);
 }
 
+#ifdef ISSUE_522
+key_action_map load_map(const std::string& filename)
+{
+
+}
+
+void save_to_file(const key_action_map& kam, const std::string& filename)
+{
+  std::ofstream file(filename);
+  file << kam;
+}
+#endif //ISSUE_522
+
+
 void test_key_action_map()//!OCLINT tests can be many
 {
 #ifndef NDEBUG // no tests in release
@@ -311,4 +326,21 @@ void test_key_action_map()//!OCLINT tests can be many
     assert(kam.to_key(action_type::shoot_stun_rocket) == sf::Keyboard::E);
   }
 #endif // FIX_ISSUE_355
+
+//#define ISSUE_522
+#ifdef ISSUE_522
+  {
+    const key_action_map kam = get_player_1_kam();
+    std::cout << kam;
+  }
+  {
+    const key_action_map kam = get_player_1_kam();
+    const std::string filename = "test.txt";
+    save_to_file(kam, filename);
+    const key_action_map map_again = load_map(filename);
+    assert(kam == map_again);
+    // TODO: delete temporary file
+  }
+#endif // ISSUE_522
+
 }

--- a/key_action_map.h
+++ b/key_action_map.h
@@ -1,7 +1,9 @@
 #ifndef KEY_TO_ACTION_MAP_H
 #define KEY_TO_ACTION_MAP_H
+
 #include "action_type.h"
-#include "SFML/Graphics.hpp"
+#include <iosfwd>
+#include <SFML/Graphics.hpp>
 
 /// Convert a key to an action
 class key_action_map
@@ -56,11 +58,20 @@ key_action_map get_random_kam();
 std::vector<key_action_map> get_n_random_kams(int n);
 
 /// Load a key-action-from file
-key_action_map load_map(const std::string& filename);
+key_action_map load_kam(const std::string& filename);
 
 /// Save the key-action-map to file
 void save_to_file(const key_action_map& kam, const std::string& filename);
 
+/// Convert a KAM to std::string
+/// @see kam_from_str to load a KAM from a std::string
+std::string to_str(const key_action_map& kam) noexcept;
+
+/// Convert a std::string to an sf::Keyboard::Key
+sf::Keyboard::Key to_sfml_key(const std::string& s);
+
+std::ostream& operator<<(std::ostream& os, const key_action_map& kam);
+std::istream& operator>>(std::istream& is, key_action_map& kam);
 bool operator==(const key_action_map& lhs, const key_action_map& rhs) noexcept;
 bool operator!=(const key_action_map& lhs, const key_action_map& rhs) noexcept;
 

--- a/key_action_map.h
+++ b/key_action_map.h
@@ -55,6 +55,12 @@ key_action_map get_random_kam();
 /// Draw at random several kams for testing purposes, with no key repeats
 std::vector<key_action_map> get_n_random_kams(int n);
 
+/// Load a key-action-from file
+key_action_map load_map(const std::string& filename);
+
+/// Save the key-action-map to file
+void save_to_file(const key_action_map& kam, const std::string& filename);
+
 bool operator==(const key_action_map& lhs, const key_action_map& rhs) noexcept;
 bool operator!=(const key_action_map& lhs, const key_action_map& rhs) noexcept;
 

--- a/player_profession.cpp
+++ b/player_profession.cpp
@@ -1,0 +1,57 @@
+#include "player_profession.h"
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <iostream>
+
+std::string to_str(player_profession this_player_profession)
+{
+  switch (this_player_profession)
+  {
+  case player_profession::hitman:
+    return "hitman";
+  case player_profession::sprinter:
+    return "sprinter";
+
+  default:
+    return "tank";
+  }
+}
+
+std::ostream& operator << (std::ostream& os, const player_profession& pro)
+{
+    os << to_str(pro);
+    return os;
+}
+
+void test_player_profession()
+{
+#ifndef NDEBUG // no tests in release
+  #define FIX_ISSUE_537
+  #ifdef FIX_ISSUE_537
+  // Each profesion is unique
+  {
+    assert(player_profession::hitman != player_profession::sprinter);
+    assert(player_profession::tank != player_profession::hitman &&
+              player_profession::tank != player_profession::sprinter);
+  }
+
+  // operator<< works
+  {
+    std::stringstream s;
+    const player_profession pro = player_profession::hitman;
+    s << pro;
+    assert(!s.str().empty());
+  }
+
+  // Conversion to string works
+  {
+    assert(to_str(player_profession::hitman) == "hitman");
+    assert(to_str(player_profession::sprinter) == "sprinter");
+    assert(to_str(player_profession::tank) == "tank");
+  }
+
+  #endif // FIX_ISSUE_537
+#endif
+}
+

--- a/player_profession.h
+++ b/player_profession.h
@@ -1,0 +1,21 @@
+#ifndef PLAYER_PROFESSION_H
+#define PLAYER_PROFESSION_H
+
+#include <string>
+#include <iosfwd>
+
+enum class player_profession
+{
+  hitman,
+  sprinter,
+  tank,
+};
+
+void test_player_profession();
+std::string to_str(player_profession this_player_profession);
+std::ostream& operator << (std::ostream& os, const player_profession& pro);
+
+/// implement << operator
+std::ostream& operator << (std::ostream& os, const player_profession& pro);
+
+#endif // PLAYER_PROFESSION_H

--- a/player_state.cpp
+++ b/player_state.cpp
@@ -42,10 +42,7 @@ void test_player_state()
     std::stringstream s;
     const player_state ps = player_state::active;
     s << ps;
-  }
-  {
-    const player_state ps = player_state::active;
-    std::cout << ps;
+    assert(!s.str().empty());
   }
   #endif // FIX_ISSUE_509
 
@@ -59,19 +56,13 @@ void test_player_state()
   }
   #endif // FIX_ISSUE_276
 
-  #define FIX_ISSUE_509
-  #ifdef FIX_ISSUE_509
-  // operator<<
+  // #509: operator<<
   {
     std::stringstream s;
     const player_state ps = player_state::active;
     s << ps;
+    assert(!s.str().empty());
   }
-  {
-    const player_state ps = player_state::active;
-    std::cout << ps;
-  }
-  #endif
   #endif
 }
 

--- a/sound_type.cpp
+++ b/sound_type.cpp
@@ -43,10 +43,7 @@ void test_sound_type()
     std::stringstream s;
     const sound_type st = sound_type::shoot;
     s << st;
-  }
-  {
-    const sound_type st = sound_type::shoot;
-    std::cout << st;
+    assert(!s.str().empty());
   }
   #endif // FIX_ISSUE_508
   #define FIX_ISSUE_263


### PR DESCRIPTION
Fixes #537 
For now player can choose among three professions: hitman, sprinter and tank. Feel free to change/add, we've not discussed their traits and abilities yet, you can consider them as just placeholders.