### PR TITLE
key-action-map of player 1 can be saved and loaded, progress #522

### DIFF
--- a/key_action_map.cpp
+++ b/key_action_map.cpp
@@ -472,7 +472,7 @@ void test_key_action_map()//!OCLINT tests can be many
     std::stringstream s;
     s << kam;
   }
-  // 522. Can save and load a key_action_map
+  // 522. Can save and load a key_action_map for player 1
   {
     const key_action_map kam = get_player_1_kam();
     const std::string filename = "test.txt";


### PR DESCRIPTION
This is some progress on #522: now the key-action-map of player 1 can be saved and loaded. For other players, this still fails, due to, for examples, arrow keys. There are helpful `assert`s for that, so that anyone can continue easily.